### PR TITLE
自分が所属するグループ一覧を左に表示

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,8 @@
 class GroupsController < ApplicationController
 
+  def index
+  end
+  
   def new
     @group = Group.new
     @group.users << current_user

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,0 +1,2 @@
+.wrapper
+  = render 'shared/leftbar'

--- a/app/views/messages/_group-list.html.haml
+++ b/app/views/messages/_group-list.html.haml
@@ -1,2 +1,0 @@
-.left-content__lower__group test-group
-.left-content__lower__first-message test-message

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,18 +1,5 @@
 .contents
-  .left-content
-    .left-content__upper
-      .left-content__upper__user 
-        = current_user.name
-      %ul.left-content__upper__icons
-        %li
-          =link_to new_group_path do
-            = fa_icon 'edit', class: "left-content__upper__icons__edit"
-        %li
-          =link_to edit_user_path(current_user) do
-            = fa_icon 'cog', class: "left-content__upper__icons__cog"
-    .left-content__lower
-      = render partial: 'group-list'
-      = render partial: 'group-list'
+  = render partial: 'shared/leftbar'
   .right-content
     .right-content__upper
       .right-content__upper__groupmembers

--- a/app/views/shared/_leftbar.html.haml
+++ b/app/views/shared/_leftbar.html.haml
@@ -1,0 +1,18 @@
+.left-content
+  .left-content__upper
+    .left-content__upper__user 
+      = current_user.name
+    %ul.left-content__upper__icons
+      %li
+        =link_to new_group_path do
+          = fa_icon 'edit', class: "left-content__upper__icons__edit"
+      %li
+        =link_to edit_user_path(current_user) do
+          = fa_icon 'cog', class: "left-content__upper__icons__cog"
+  .left-content__lower
+    - current_user.groups.each do |group|
+      = link_to '#' do
+        .left-content__lower__group
+          = group.name
+        .left-content__lower__first-message
+          メッセージはまだありません。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
-  root to: 'messages#index'
+  root to: 'groups#index'
   resources :users, only: [:edit, :update]
-  resources :groups, only: [:new, :create, :edit, :update]
+  resources :groups, only: [:index, :new, :create, :edit, :update] do
+    resources :messages, only: [:index]
+  end
 end


### PR DESCRIPTION
最初にログインした時にgroupsコントローラのindexアクションが起動するようにした。このviewとmessagesのindexで表示するviewの、左側のバーが同じなので、部分テンプレート(shared/_leftbar.html.haml)に切り分けて、それぞれのviewで利用するようにした。