### PR TITLE
グループ編集機能と、editボタンのリンク貼り

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,4 +1,5 @@
 class GroupsController < ApplicationController
+  before_action :set_group, only: [:edit, :update]
 
   def index
   end
@@ -17,14 +18,20 @@ class GroupsController < ApplicationController
     end
   end
 
-  def edit
-  end
-
   def update
+    if @group.update(group_params)
+      redirect_to group_messages_path(@group), notice: 'グループを編集しました'
+    else
+      render :edit
+    end
   end
   
   private
   def group_params
     params.require(:group).permit(:name, user_ids: [] )
+  end
+
+  def set_group
+    @group = Group.find(params[:id])
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,7 @@
 class MessagesController < ApplicationController
+
   def index
+    @group = Group.find(params[:group_id])
   end
+
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,0 +1,25 @@
+= form_for group do |f|
+  - if group.errors.any?
+    .chat-group-form__errors
+      %h2= "#{group.errors.full_messages.count}件のエラーが発生しました。"
+      %ul
+        - group.errors.full_messages.each do |message|
+          %li= message
+  .chat-group-form__field
+    .chat-group-form__field--left
+      = f.label :name, class: 'chat-group-form__label'
+    .chat-group-form__field--right
+      = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+  .chat-group-form__field.clearfix
+    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+    .chat-group-form__field--right
+      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+      = f.collection_check_boxes :user_ids, User.all, :id, :name
+      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+    .chat-group-form__field--right
+      = f.submit class: 'chat-group-form__action-btn'

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,24 +1,3 @@
 .chat-group-form
   %h1 チャットグループ編集
-  %form#edit_chat_group_22.edit_chat_group{"accept-charset" => "UTF-8", :action => "/chat_groups/22", :method => "post"}
-    .chat-group-form__errors
-      %h2
-        1件のエラーが発生しました。
-        %ul
-          %li エラーです
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
-      .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text", value: "ほげー"}/
-    .chat-group-form__field.clearfix
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
-        %input.chat-group-form__action-btn{"data-disable-with":"Save", name: "commit", type: "submit", value: "Save"}/
+  = render partial: 'form', locals: { group: @group }

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,27 +1,3 @@
 .chat-group-form
   %h1 新規チャットグループ
-  = form_for @group do |f|
-    - if @group.errors.any?
-      .chat-group-form__errors
-        %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
-        %ul
-          - @group.errors.full_messages.each do |message|
-            %li= message
-    .chat-group-form__field
-      .chat-group-form__field--left
-        = f.label :name, class: 'chat-group-form__label'
-      .chat-group-form__field--right
-        = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
-    .chat-group-form__field.clearfix
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化)のときに使用します
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        = f.label "チャットメンバー", class: "chat-group-form__label"
-      .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        = f.collection_check_boxes :user_ids, User.all, :id, :name
-        / この部分はインクリメンタルサーチ（ユーザー追加の非同期化)のときにも使用します
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        = f.submit class: 'chat-group-form__action-btn'
+  = render 'form', { group: @group }

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -5,7 +5,9 @@
       .right-content__upper__groupmembers
         .right-content__upper__groupmembers__group test-group
         .right-content__upper__groupmembers__members Member : aaa bbb
-      .right-content__upper__btn Edit
+      = link_to edit_group_path(@group) do
+        .right-content__upper__btn
+          Edit
     .right-content__middle
       = render partial: 'group-message'
       = render partial: 'group-message'
@@ -15,6 +17,6 @@
         .right-content__lower__textbox__imagefolder
           %label.upload-label
             %i.fa.fa-image
-            %input.upload-image{:type => "file"}
+            %input.upload-image{type: "file"}
       .right-content__lower__btn
         .right-content__lower__btn__text Send

--- a/app/views/shared/_leftbar.html.haml
+++ b/app/views/shared/_leftbar.html.haml
@@ -11,7 +11,7 @@
           = fa_icon 'cog', class: "left-content__upper__icons__cog"
   .left-content__lower
     - current_user.groups.each do |group|
-      = link_to '#' do
+      = link_to group_messages_path(group) do
         .left-content__lower__group
           = group.name
         .left-content__lower__first-message


### PR DESCRIPTION
groupsのeditとupdateの機能を実装した。コントローラの設定と、ビューの整理。左のグループ一覧の、グループ名をクリックすることでグループの編集(edit and update)する為のページに飛ぶようにしている。group/messagesのページの右上のEditボタンを押すとgroupの編集画面に飛ぶようにした。