### PR TITLE
メッセージの自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -69,6 +69,6 @@ $(function(){
   };
   let path = location.pathname.split("/")
   if (path[1] == "groups" && path[3] == "messages"){
-    setInterval(reloadMessages, 5000);
+    setInterval(reloadMessages, 1000);
   }
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -48,9 +48,9 @@ $(function(){
     last_message_id = $(".right-content__middle__userdate").last().data('id');
     $.ajax({
       url: "api/messages",
-      type: 'get',
-      dataType: 'json',
-      data: {id: last_message_id}
+      type: "get",
+      data: { id: last_message_id },
+      dataType: "json"
     })
     .done(function(messages) {
       let insertHTML = '';
@@ -58,14 +58,17 @@ $(function(){
         insertHTML += buildHTML(message);
       });
       $(".right-content__middle").append(insertHTML)
+      if (messages.length !== 0) {
       $(".right-content__middle").animate({
         scrollTop: $(".right-content__middle")[0].scrollHeight}, 'fast');
+      }
     })
     .fail(function() {
       console.log('error');
     });
   };
-  if (path == "/groups/[\d]+/messages"){
+  let path = location.pathname.split("/")
+  if (path[1] == "groups" && path[3] == "messages"){
     setInterval(reloadMessages, 5000);
   }
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -65,5 +65,7 @@ $(function(){
       console.log('error');
     });
   };
-  setInterval(reloadMessages, 5000);
+  if (path == "/groups/[\d]+/messages"){
+    setInterval(reloadMessages, 5000);
+  }
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -53,7 +53,11 @@ $(function(){
       data: {id: last_message_id}
     })
     .done(function(messages) {
-      console.log('success');
+      let insertHTML = '';
+      messages.forEach(function(message){
+        insertHTML += buildHTML(message);
+      });
+      $(".right-content__middle").append(insertHTML)
     })
     .fail(function() {
       console.log('error');

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -58,9 +58,12 @@ $(function(){
         insertHTML += buildHTML(message);
       });
       $(".right-content__middle").append(insertHTML)
+      $(".right-content__middle").animate({
+        scrollTop: $(".right-content__middle")[0].scrollHeight}, 'fast');
     })
     .fail(function() {
       console.log('error');
     });
   };
+  setInterval(reloadMessages, 5000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -64,7 +64,7 @@ $(function(){
       }
     })
     .fail(function() {
-      console.log('error');
+      alert("通信エラーです。");
     });
   };
   let path = location.pathname.split("/")

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -43,4 +43,20 @@ $(function(){
         $(".right-content__lower__btn").removeAttr('disabled');
     });
   })
+
+  let reloadMessages = function() {
+    last_message_id = $(".right-content__middle__userdate").last().data('id');
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      console.log('success');
+    })
+    .fail(function() {
+      console.log('error');
+    });
+  };
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,9 +1,10 @@
 $(function(){
   function buildHTML(message){
 
+    let id = message.id
     let text_image = `<p>${message.content}</p>
                       <img src="${message.image_url}" alt="graphics">`
-    let html = `<div class="right-content__middle__userdate">
+    let html = `<div class="right-content__middle__userdate" data-id="${id}">
                   <div class="right-content__middle__userdate__user">
                     ${message.user_name}
                   </div>
@@ -11,7 +12,7 @@ $(function(){
                     ${message.created_at}
                   </div>
                 </div>
-                <div class="right-content__middle__message">
+                <div class="right-content__middle__message" data-id="${id}">
                   ${message.image_url ? text_image : message.content }
                 </div>
                   `

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.include(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -2,6 +2,6 @@ class Api::MessagesController < ApplicationController
   def index
     group = Group.find(params[:group_id])
     last_message_id = params[:id].to_i
-    @messages = group.messages.include(:user).where("id > #{last_message_id}")
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
   end
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image_url message.image.url
+  json.user_name message.user.name
+  json.created_at message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.id @message.id
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -3,5 +3,5 @@ json.array! @messages do |message|
   json.image_url message.image.url
   json.user_name message.user.name
   json.created_at message.created_at.strftime("%Y/%m/%d %H:%M")
-  json.id @message.id
+  json.id message.id
 end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,9 +1,9 @@
-.right-content__middle__userdate
+.right-content__middle__userdate{data: {id: "#{message.id}"}}
   .right-content__middle__userdate__user
     = message.user.name
   .right-content__middle__userdate__date
     = message.created_at.strftime("%Y/%m/%d %H:%M")
-.right-content__middle__message
+.right-content__middle__message{data: {id: "#{message.id}"}}
   %p 
     = message.content
   = image_tag message.image.url, class: 'image' if message.image.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.content @message.content
 json.image_url @message.image.url
 json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
グループページのメッセージ一覧が自動更新されるよう実装を行なった。１秒ごとに、現在画面に表示されている最新のメッセージと、データベース上のメッセージを比べて、画面に無いメッセージをデータベースから持ってきて、非同期通信で画面に追加する。

# Why
ユーザーが他の人とチャットする時、他の人がどのタイミングでメッセージを投稿するか分からないのに、メッセージを得る手段が画面のリロードのみだと、頻繁にリロードし続けないといけないので不便。自動更新機能があれば、他の人がメッセージを投稿したのとほぼ間をおかずにそのメッセージを確認できて、チャットが円滑に進む。

# Capture
## 2画面、それぞれ別のユーザーから見た自動更新の様子（テキストのみ投稿）
https://gyazo.com/1fa8c9ade728c55ede2bb95a614b43e9

## 2画面、画像のみ投稿
https://gyazo.com/7a373ac9ca2a6caf42d0fc8f12f3ac44

## ２画面、テキスト＋画像投稿
https://gyazo.com/fe3b279d3b7178660b86715ab0cd1695