### PR TITLE
turbolinksをfalse設定に

### DIFF
--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -9,7 +9,7 @@
           Member : 
           - @group.group_users.each do |group_user|
             = group_user.user.name
-      = link_to edit_group_path(@group) do
+      = link_to edit_group_path(@group), {data: {"turbolinks": false}} do
         .right-content__upper__btn
           Edit
     .right-content__middle

--- a/app/views/shared/_leftbar.html.haml
+++ b/app/views/shared/_leftbar.html.haml
@@ -4,14 +4,14 @@
       = current_user.name
     %ul.left-content__upper__icons
       %li
-        =link_to new_group_path do
+        =link_to new_group_path, {data: {"turbolinks": false}} do
           = fa_icon 'edit', class: "left-content__upper__icons__edit"
       %li
-        =link_to edit_user_path(current_user) do
+        =link_to edit_user_path(current_user), {data: {"turbolinks": false}} do
           = fa_icon 'cog', class: "left-content__upper__icons__cog"
   .left-content__lower
     - current_user.groups.each do |group|
-      = link_to group_messages_path(group) do
+      = link_to group_messages_path(group), {data: {"turbolinks": false}} do
         .left-content__lower__group
           = group.name
         .left-content__lower__first-message


### PR DESCRIPTION
link_toを使ってページに移動すると、そのページでjavascriptが働かないことがある。このアプリのコードの仕様上jsはページがリロードされないと動かないが、linkで移動すると、最初の移動はともかく、２度目以降はページがリロードされず、結果jsが動かない。
この問題は、link_toにturbolinksを無効化するオプションを加えれば解決するとわかったので、そうした。